### PR TITLE
feat: sticky sessions and default error log verb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ WORKDIR /build/sources/
 RUN wget https://nginx.org/download/nginx-1.14.0.tar.gz
 # Grab the VTS plugin source
 RUN git clone https://github.com/vozlt/nginx-module-vts.git
-
+# Grab the stickey session plugin
+RUN git clone https://bitbucket.org/nginx-goodies/nginx-sticky-module-ng.git
 # Build with VTS plugin
 RUN tar -zxf nginx-1.14.0.tar.gz
 WORKDIR /build/sources/nginx-1.14.0
@@ -42,7 +43,8 @@ RUN ./configure --prefix=/etc/nginx  \
                 --with-http_ssl_module \
                 --with-stream \
                 --with-mail=dynamic \
-                --add-module=../nginx-module-vts
+                --add-module=../nginx-module-vts \
+                --add-module=../nginx-sticky-module-ng
 RUN make
 RUN make install
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 
 [![Docker Repository on Quay](https://quay.io/repository/utilitywarehouse/nginx-prometheus/status "Docker Repository on Quay")](https://quay.io/repository/utilitywarehouse/nginx-prometheus)
 ## About
-A build of Nginx with a 3rd party plugin, Virtual Traffic Status (VTS) which provides an instrumented deployment of Nginx on alpine.
+A build of Nginx with 3rd party plugins, Virtual Traffic Status (VTS) which provides an instrumented deployment of Nginx on alpine and nginx-sticky-module-ng which provides sticky sessions for upstreams.
 * https://github.com/vozlt/nginx-module-vts
 * http://nginx.org/en/docs/configure.html
+* https://bitbucket.org/nginx-goodies/nginx-sticky-module-ng.git
 
 ## Running
 you can run this image as a Docker container
@@ -28,6 +29,9 @@ The instance will expose stats on the `8080` port, multiple formats are supporte
 * html - `/status/format/html`
 * jsonp - `/status/format/jsonp`
 * prometheus- `/status/format/prometheus`
+
+### Sticky sessions for Upstreams
+For more information on this plugin please refer to the code owners documentation https://bitbucket.org/nginx-goodies/nginx-sticky-module-ng.git
 
 for more information on exposed metrics and use of the control endpoint please head over to https://github.com/vozlt/nginx-module-vts and read the manual/docs
 

--- a/build/nginx.conf
+++ b/build/nginx.conf
@@ -4,7 +4,7 @@ daemon    off;
 user  nobody;
 worker_processes  1;
 
-error_log /dev/stdout debug;
+error_log /dev/stdout error;
 
 events {
     worker_connections  1024;
@@ -18,7 +18,7 @@ http {
     #                  '$status $body_bytes_sent "$http_referer" '
     #                  '"$http_user_agent" "$http_x_forwarded_for"';
 
-    access_log  /dev/stdout  combined;
+    #access_log  /dev/stdout  combined;
 
     sendfile        on;
     #tcp_nopush     on;


### PR DESCRIPTION
provides the sticky sessions plugin for upstream servers
provides `error` as the default error log verbosity